### PR TITLE
Move PropTypes from react to prop-types package

### DIFF
--- a/Example/src/SignatureView.js
+++ b/Example/src/SignatureView.js
@@ -1,6 +1,8 @@
 import React, {
-  Component, PropTypes
+  Component
 } from 'react';
+
+import PropTypes from 'prop-types'
 
 import ReactNative, {
   View, Text, Modal, Platform, Alert

--- a/SignatureCapture.js
+++ b/SignatureCapture.js
@@ -3,9 +3,9 @@
 
 var ReactNative = require('react-native');
 var React = require('react');
-var {
-    PropTypes
-} = React;
+
+import PropTypes from 'prop-types'
+
 var {
     requireNativeComponent,
     View,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-signature-capture",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Lets users sign their signatures",
   "main": "SignatureCapture.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-signature-capture",
-  "version": "0.4.6",
+  "version": "0.4.5",
   "description": "Lets users sign their signatures",
   "main": "SignatureCapture.js",
   "scripts": {


### PR DESCRIPTION
When upgrading to react native > 0.48 we get problems with react prop types.

I tested this changes in my project and it's work.